### PR TITLE
Update on Server_zf

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,15 +63,17 @@ var avatars = require('./routes/avatars');
 var rooms = require('./routes/rooms');
 var matchmaking = require('./routes/matchmaking');
 var wiki = require('./routes/wiki');
+var judging = require('./routes/judging');
 
 // Specify routes
 app.use('/', routes);
+app.use('/auth', auth);
 app.use('/users', users);
 app.use('/avatars', avatars);
 app.use('/rooms', rooms);
 app.use('/matchmaking', matchmaking);
 app.use('/wiki', wiki);
-app.use('/auth', auth);
+app.use('/judging', judging);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/db/db_config.js
+++ b/db/db_config.js
@@ -258,9 +258,14 @@ var rooms = sequelize.define('rooms', {
   },
   // The number of turns that have passed
   turnCount: {
-    type: Sequelize.INTEGER(),
+    type: Sequelize.INTEGER,
     allowNull: false,
     defaultValue: 0
+  },
+  // The avatarID of the winner
+  winnerAvatarID: {
+    type: Sequelize.INTEGER,
+    allowNull: true
   },
   // Room createdAt time
   createdAt: {
@@ -339,12 +344,12 @@ users.sync().then(function () {
   // Sync to avatars table
   avatars.sync().then(function () {
     // Table created
-    console.log('Synced to avatar Table');
+    console.log('Synced to Avatar Table');
 
     // Sync to avatarStats table
     avatarStats.sync().then(function () {
       // Table created
-      console.log('Synced to avatar Stats Table');
+      console.log('Synced to Avatar Stats Table');
 
       // Sync to rooms table
       rooms.sync().then(function () {

--- a/db/db_config.js
+++ b/db/db_config.js
@@ -235,11 +235,26 @@ var rooms = sequelize.define('rooms', {
       key: 'id'
     }
   },
-  // Boolean to decide if room is active or ready for judging
-  isOpen: {
-    type: Sequelize.BOOLEAN(),
+  // First avatar's votes
+  avatar1_votes: {
+    type: Sequelize.INTEGER,
     allowNull: false,
-    defaultValue: true
+    defaultValue: 0
+  },
+  // Second avatar's votes
+  avatar2_votes: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    defaultValue: 0
+  },
+  // Number to decide roomstate
+  // 0 is active (users are playing)
+  // 1 is in voting (game complete and winner is being decided)
+  // 2 is closed (game completed and winner decided)
+  roomState: {
+    type: Sequelize.INTEGER(4),
+    allowNull: false,
+    defaultValue: 0
   },
   // The number of turns that have passed
   turnCount: {

--- a/db/roomsHelper.js
+++ b/db/roomsHelper.js
@@ -44,26 +44,26 @@ var socketHelper = require('../server/sockets').helper;
 var roomsHelper = {};
 
 // Rooms helper to get n rooms that need to be judged
-roomsHelper.getRoomsToJudge = function (data) {
-  // Get callback
-  var callback = data.callback;
+// roomsHelper.getRoomsToJudge = function (data) {
+//   // Get callback
+//   var callback = data.callback;
 
-  // Get userID
-  var callback = data.callback;
+//   // Get userID
+//   var callback = data.callback;
 
-  // Room count limit
-  var roomLimit = data.roomLimit || 10;
+//   // Room count limit
+//   var roomLimit = data.roomLimit || 10;
 
-  // Get roomLimit rooms to judge
-  return roomsTable.findAll({
-    where: {
-      isOpen: false
-    },
-    limit: roomLimit
-  }).then(function (roomsFound) {
+//   // Get roomLimit rooms to judge
+//   return roomsTable.findAll({
+//     where: {
+//       roomState: false
+//     },
+//     limit: roomLimit
+//   }).then(function (roomsFound) {
     
-  });
-};
+//   });
+// };
 
 // Rooms helper method to add to end of game queue
 roomsHelper.enqueueToPlay = function (data) {
@@ -129,11 +129,11 @@ roomsHelper.canJoinMatchmaking = function (data) {
           $or: [
             {
               avatar1_id: avatarID,
-              isOpen: true
+              roomState: 0
             },
             {
               avatar2_id: avatarID,
-              isOpen: false
+              roomState: 0
             }
           ]}
       }).then(function (roomsFound) {
@@ -413,8 +413,8 @@ roomsHelper.sendMessageToRoom = function (data) {
   }).then(function (roomFound) {
     // Only continue if the room was found
     if (roomFound) {
-      // Only continue if room is open
-      if (roomFound.dataValues.isOpen) {
+      // Only continue if room is open/active
+      if (roomFound.dataValues.roomState === 0) {
         // Get avatar 1 or avatar 2
         var avatarNum = 0;
         // If avatar 1
@@ -447,11 +447,12 @@ roomsHelper.sendMessageToRoom = function (data) {
               result.messageData = messageCreated;
 
               // Check if game needs to close
-              var isOpen = roomFound.dataValues.turnCount < 5;
+              var roomState
+                = (roomFound.dataValues.turnCount < 5 ? 0 : 1);
               // Update turn count
               return roomFound.update({
                 turnCount: roomFound.dataValues.turnCount + 1,
-                isOpen: isOpen
+                roomState: roomState
               }).then(function () {
 
                 // Update turn count and invoke callback
@@ -492,7 +493,7 @@ roomsHelper.sendMessageToRoom = function (data) {
 
 
                 // If the game is over
-                if (!isOpen) {
+                if (roomState === 1) {
                   // Add the room to judging
                   judging.addRoom(roomID, roomsHelper.getRoomData);
                 }

--- a/routes/judging.js
+++ b/routes/judging.js
@@ -27,7 +27,7 @@ var judging = require('../server/data').judging;
 // | | | (_) | |_| | ||  __/\__ \
 // |_|  \___/ \__,_|\__\___||___/
 
-// POST to join voting queue
+// GET route to receive rooms to judge for a client
 router.get('/', authenticator.ensureAuthenticated,
   function (req, res, next) {
   // Expected request body example
@@ -52,4 +52,35 @@ router.get('/', authenticator.ensureAuthenticated,
   // Expected result sent to client
   // [roomObj1, roomObj2, ...]
 });
+
+// PUT route to cast a vote for a specified roomID
+router.put('/:roomID', authenticator.ensureAuthenticated,
+  function (req, res, next) {
+  // Expected request body example
+  // {}
+
+  // Decrypt token
+  var decrypted = req.body.decrypted;
+
+  // Data to pass to judging
+  var data = {
+    // User ID
+    userID: decrypted.userID,
+    // Room ID
+    roomID: req.params.roomID,
+    // Up vote ID (1 or 2 for avatar1 or avatar2)
+    upVoteID: req.body.upVoteID,
+  };
+  // Callback
+  var callback = function (result) {
+    res.send(result);
+  };
+
+  // Log
+  console.log('\n\nATTEMPTING TO CAST VOTE ON ROOM',
+    data.roomID, 'FOR AVATAR', upVoteID);
+  // Handoff to judging
+  judging.judgeOneRoom(data, callback);
+});
+
 module.exports = router;

--- a/routes/voting.js
+++ b/routes/voting.js
@@ -18,7 +18,7 @@ var router = express.Router();
 var authenticator = require('../server/authenticator');
 
 // Require rooms helper
-var roomsHelper = require('../db/roomsHelper');
+var judging = require('../server/data').judging;
 
 //                  _            
 //                 | |           
@@ -28,7 +28,7 @@ var roomsHelper = require('../db/roomsHelper');
 // |_|  \___/ \__,_|\__\___||___/
 
 // POST to join voting queue
-router.post('/', authenticator.ensureAuthenticated,
+router.get('/', authenticator.ensureAuthenticated,
   function (req, res, next) {
   // Expected request body example
   // {}
@@ -36,25 +36,20 @@ router.post('/', authenticator.ensureAuthenticated,
   // Decrypt token
   var decrypted = req.body.decrypted;
 
-  // Data to pass to voting enqueue
-  var data = {
-    // UserID
-    userID: decrypted.userID,
-    // Callback
-    callback: function (result) {
-      res.send(result);
-    }
+  // User ID
+  var userID = decrypted.userID;
+  // Callback
+  var callback = function (result) {
+    res.send(result);
   };
 
   // Log
-  console.log('\n\nATTEMPTING ADDING TO BACK OF LINE:',
-    data.avatarID, '\n\n');
+  console.log('\n\nATTEMPTING TO GET ROOMS TO JUDGE FOR',
+    userID, '\n\n');
   // Attempt to add to voting queue
-  roomsHelper.queueForVote(data);
+  judging.getRoomsToJudge(userID, callback);
 
   // Expected result sent to client
-  // {
-  //   inVotingQueue: true
-  // }
+  // [roomObj1, roomObj2, ...]
 });
 module.exports = router;

--- a/server/data.js
+++ b/server/data.js
@@ -216,13 +216,15 @@ judging.getRoomsToJudge = function (userID, callback) {
       // If the user hasn't judged this room yet
       if (!(userIDin 
         in this.roomDataForServer[roomIDs[i]].usersWhoVoted)) {
+        
         // Add to rooms to judge
         roomsToJudge.push(this.roomDataForClient[i]);
+
+        // If the roomsToJudge count is exceeds the max, break
+        if (judging.judgeRequestRoomMax <= roomsToJudge.length) {
+          break;
+        }
       }
-    }
-    // If the roomsToJudge count is exceeds the max, break
-    if (judging.judgeRequestRoomMax <= roomsToJudge.length) {
-      break;
     }
   }
 

--- a/server/data.js
+++ b/server/data.js
@@ -114,7 +114,7 @@ judging.print = function () {
   str += ']\n';
 
   // Print the string
-  console.log(str);
+  // console.log(str);
 };
 
 // Judging starting time
@@ -128,7 +128,7 @@ judging.updateRooms = function () {
   var currTime = Date.now();
   // Delta time between last judging
   var deltaTime = currTime - this.lastTime;
-  console.log('Time since judging update:', deltaTime + 'ms');
+  // console.log('Time since judging update:', deltaTime + 'ms');
   // Iterate over rooms from newest to oldest
   for (var i = roomIDs.length - 1; -1 < i; --i) {
     // Subtract from the time to expire for the room

--- a/server/data.js
+++ b/server/data.js
@@ -165,11 +165,31 @@ judging.archiveRoom = function (roomID) {
   }).then(function (roomFound) {
     // If the room was found
     if (roomFound) {
-      // Set it's roomState to 2 (archived)
+      // Get winner for room
+
+      // Assume tie
+      var winnerAvatarID = -1;
+      // Get vote counts
+      var avatar1Votes
+        = judging.roomDataForServer[roomID].avatar1Votes;
+      var avatar1Votes
+        = judging.roomDataForServer[roomID].avatar1Votes;
+      // If either avatar 1 or 2 won, reset winnerAvatarID
+      if (avatar1Votes < avatar2Votes) {
+        winnerAvatarID = roomFound.dataValues.avatar2_id;
+      } else if (avatar2Votes < avatar1Votes) {
+        winnerAvatarID = roomFound.dataValues.avatar1_id;
+      }
+
+      // Set it's roomState to 2 (archived) and the winnerAvatarID
       roomFound.update({
-        roomState: 2
+        roomState: 2,
+        winnerAvatarID: winnerAvatarID
       });
     }
+
+    // Send live update if possible, or store notifications
+    // for next time users log in
   });
 };
 

--- a/server/data.js
+++ b/server/data.js
@@ -208,7 +208,7 @@ judging.getRoomsToJudge = function (userID, callback) {
   // Time to expire cutoff
   var cutoffTTE = Math.round(this.initialTTE/2);
 
-  // iterte over all possible rooms to judge
+  // Iterate over all possible rooms to judge
   for (var i = 0; i < roomIDs.length; ++i) {
     // If the TTE isn't high enough, skip
     if (this.roomDataForServer[roomIDs[i]].timeToExpire
@@ -216,7 +216,7 @@ judging.getRoomsToJudge = function (userID, callback) {
       // If the user hasn't judged this room yet
       if (!(userIDin 
         in this.roomDataForServer[roomIDs[i]].usersWhoVoted)) {
-        
+
         // Add to rooms to judge
         roomsToJudge.push(this.roomDataForClient[i]);
 
@@ -255,6 +255,9 @@ judging.judgeOneRoom = function (data, callback) {
     this.roomDataForServer[roomID].usersWhoVoted[userID] = true;
     // Set cast vote to true
     result.voteCast = true;
+  } else {
+    // Room ID wasn't found
+    result.badRoomID = true;
   }
 
   // Invoke callback

--- a/server/data.js
+++ b/server/data.js
@@ -181,10 +181,13 @@ judging.archiveRoom = function (roomID) {
         winnerAvatarID = roomFound.dataValues.avatar1_id;
       }
 
-      // Set it's roomState to 2 (archived) and the winnerAvatarID
+      // Set it's roomState to 2 (archived) and the winnerAvatarID,
+      // in addition to the vote counts
       roomFound.update({
         roomState: 2,
-        winnerAvatarID: winnerAvatarID
+        winnerAvatarID: winnerAvatarID,
+        avatar1_votes: avatar1Votes,
+        avatar2_votes: avatar2Votes
       });
     }
 

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -48,9 +48,6 @@ io.on("connection", function (socket) {
     });
   });
 
-  // Check client connection
-  socket.emit('hello', 'hey world');
-
   // Give client their socketID for token
   helper.giveSocketID({socketID: socket.id});
 });
@@ -114,6 +111,11 @@ helper.clientJoinRoom = function (data, callback) {
   var socket_1 = onlineUsers[userID_1];
   var socket_2 = onlineUsers[userID_2];
 
+  console.log(onlineUsers);
+  console.log('SOCKET1:', socket_1);
+  console.log('SOCKET2:', socket_2);
+  console.log('USER1:', userID_1);
+  console.log('USER2:', userID_2);
   // Only emit live update if either user is online
   if (socket_1 || socket_2) {
     // Get room data by callback

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -111,11 +111,6 @@ helper.clientJoinRoom = function (data, callback) {
   var socket_1 = onlineUsers[userID_1];
   var socket_2 = onlineUsers[userID_2];
 
-  console.log(onlineUsers);
-  console.log('SOCKET1:', socket_1);
-  console.log('SOCKET2:', socket_2);
-  console.log('USER1:', userID_1);
-  console.log('USER2:', userID_2);
   // Only emit live update if either user is online
   if (socket_1 || socket_2) {
     // Get room data by callback
@@ -145,7 +140,7 @@ helper.clientTurnUpdate = function (data, callback) {
   var opponentUserID = data.opponentUserID;
   // Get roomID
   var roomID = data.roomID;
-  console.log('opponent:', opponentUserID);
+
   // Get opponent socket
   var opponentSocket = onlineUsers[opponentUserID];
 


### PR DESCRIPTION
Commit 1:
- Refactored isOpen in rooms table to roomState
  - 0: room is in play
  - 1: room is in voting and finished playing
  - 2: room is archived, finished voting, and finished playing
- Rooms that timeout of voting are successfully archived and
  removed from judging list

Commit 2:
- In ./server/data.js:
  - Added getRoomsToJudge () to judging data object
  - Added judgeOneRoom () to judging data object

Commit 3:
- Removed debug logging from data.js for juding {}

Commit 4:
- Added avatarWinnerID column to rooms table

Commit 5:
- Removed debug logging from clientJoinRoom () in ./server/sockets.js
  TODO:
- Force logout for userIDs logged into multiple browsers
  - NOTE (only keep most recently logged in userID's socket logged in)

Commit 6:
- Added functionality to judging {} to set the winner when invoking
  archiveRoom () by comparing the upvotes for avatar1 and avatar2

Commit 7:
- Save vote counts to database during judged room's archiving

Commit 8:
- Moved 'max rooms to judge limit reached' breaking condition so
  it is only check when a room is added to roomsToJudge in
  judging {}'s getRoomsToJudge ()
- Setup GET route for voting to return rooms to be judged

Commit 9:
- Renamed 'voting' route to 'judging'
- Added judging routes file to ./app.js
- Added PUT request to judging route to cast a vote for a specified
  roomID and upVoteID corresponding to 1 or 2 for avatar 1 or 2
